### PR TITLE
Remove trailing newline in branch normal output

### DIFF
--- a/pynessie/commands/_branch_tag_handlers.py
+++ b/pynessie/commands/_branch_tag_handlers.py
@@ -139,4 +139,6 @@ def _handle_normal_output(input_data: list, verbose: bool, default_branch: str, 
             additional_info,
         )
         output += click.style(next_row, fg="yellow") if x.name == default_branch else next_row
+    # remove latest newline
+    output = "".join(output.rsplit("\n", 1))
     return output


### PR DESCRIPTION
Remove the trailing newline in returned output from `_handle_normal_output`
This helps for counting branches accurately with wc. 
We cannot use rstrip because the styling that can be applied after the newline.